### PR TITLE
Move maven level up to 3.5.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ hello-api/target
 chart/.DS_Store
 chart/lagomjavatemplate/.DS_Store
 target
+.project

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.5.2-jdk-8-alpine AS builder
+FROM maven:3.5.4-jdk-8-alpine AS builder
 COPY pom.xml .
 COPY hello-api hello-api/
 COPY hello-impl hello-impl/


### PR DESCRIPTION
Move maven level up to 3.5.4 because older levels are not available in dockerhub for ppc and s390x.